### PR TITLE
Fixes #1 - Fail fast on missing type hints

### DIFF
--- a/simplecli/simplecli.py
+++ b/simplecli/simplecli.py
@@ -311,8 +311,6 @@ def params_to_kwargs(
     missing_params = []
     try:
         for param in params:
-            if param.annotation is Empty:
-                exit("ERROR: All wrapped function parameters need type hints!")
             # Positional arguments take precedence
             if pos_args:
                 param.set_value(pos_args.pop(0))
@@ -406,19 +404,18 @@ def wrap(func: Callable[..., Any]) -> Callable[..., Any]:
 
 def code_to_ordered_params(code: Callable[..., Any]) -> OrderedDict:
     signature = inspect.signature(code)
-    empty = inspect._empty
-    return OrderedDict(
-        (
-            k,
-            Param(
-                name=v.name,
-                default=Empty if v.default is empty else v.default,
-                annotation=Empty if v.annotation is empty else v.annotation,
-                kind=v.kind,
-            ),
+    result = OrderedDict()
+
+    for k, v in signature.parameters.items():
+        if v.annotation is inspect._empty:
+            exit("ERROR: All wrapped function parameters need type hints!")
+        result[k] = Param(
+            name=v.name,
+            default=Empty if v.default is inspect._empty else v.default,
+            annotation=v.annotation,
+            kind=v.kind,
         )
-        for k, v in signature.parameters.items()
-    )
+    return result
 
 
 def process_comment(

--- a/simplecli/simplecli.py
+++ b/simplecli/simplecli.py
@@ -311,6 +311,8 @@ def params_to_kwargs(
     missing_params = []
     try:
         for param in params:
+            if param.annotation is Empty:
+                exit("ERROR: All wrapped function parameters need type hints!")
             # Positional arguments take precedence
             if pos_args:
                 param.set_value(pos_args.pop(0))

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -217,3 +217,36 @@ def test_directly_called_wrap(monkeypatch):
 
     assert nt.code(1, foo="test") == "2 test!"
     assert nt.code(test_id=2, foo="blarg") == "3 blarg!"
+
+
+def test_wrap_no_typehint_(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["filename", "123"])
+
+    def code1(foo):
+        pass
+
+    with pytest.raises(SystemExit, match="parameters need type hints!"):
+        code1.__globals__["__name__"] = "__main__"
+        simplecli.wrap(code1)
+
+
+def test_wrap_no_typehint_no_arg(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["filename"])
+
+    def code1(foo):
+        pass
+
+    with pytest.raises(SystemExit, match="ERROR: All wrapped function "):
+        code1.__globals__["__name__"] = "__main__"
+        simplecli.wrap(code1)
+
+
+def test_wrap_no_typehint_kwarg(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["filename", "--foo"])
+
+    def code1(foo):
+        pass
+
+    with pytest.raises(SystemExit, match="function parameters need type"):
+        code1.__globals__["__name__"] = "__main__"
+        simplecli.wrap(code1)


### PR DESCRIPTION
Missing type hints means we have no way of validating data. Clearly display why we're erroring out.